### PR TITLE
Stop pam from also declaring Class[Authselect]

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,6 @@ fixtures:
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     oddjob: https://github.com/simp/pupmod-simp-oddjob.git
     pam: https://github.com/simp/pupmod-simp-pam
-    simp_authselect: https://github.com/simp/pupmod-simp-simp_authselect
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,8 +30,13 @@ class simp_authselect (
   Boolean       $use_authselect      = simplib::lookup('simp_options::authselect', { 'default_value' => false }),
 ) {
   if $use_authselect {
+    # simp_authselect takes full ownership of the authselect class and custom
+    # profile declaration below, so pam must not also try to do it (otherwise
+    # both modules race to declare Class[Authselect] and Authselect::Custom_profile
+    # with different parameters).
     class { 'pam':
-      auth_sections => $authselect_sections
+      auth_sections  => $authselect_sections,
+      use_authselect => false,
     }
 
     $contents = $authselect_sections.reduce({}) |$memo, $section| {


### PR DESCRIPTION
## Summary

- When `simp_options::authselect` is true, both `simp_authselect` and `pam` independently declare `class { 'authselect': ... }` (and an `authselect::custom_profile` resource for the same profile name) with different parameters. Puppet rejects this with a duplicate-declaration error during compilation.
- `simp_authselect` always intended to own the authselect declaration (it sets `profile_manage`, `profile`, and `custom_profiles`). Now it explicitly passes `use_authselect => false` to pam so pam skips its own authselect branch when simp_authselect is driving things.
- Also dropped the self-referential `simp_authselect` entry from `.fixtures.yml`'s `repositories` list. The `symlinks` entry already points the simp_authselect fixture at the source dir; the duplicate `repositories` entry caused `rake spec_prep` to clone an upstream copy that masked local changes during testing.

## Test plan

- [x] `bundle exec rubocop` — clean (4 files inspected, 0 offenses)
- [x] `bundle exec rake spec` — 162 examples, 0 failures (Puppet 8 in `ruby:3.2` container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)